### PR TITLE
AttributeError: 'QWebFrame' object has no attribute 'pageChanged' 

### DIFF
--- a/webkitd.py
+++ b/webkitd.py
@@ -617,7 +617,8 @@ class WebKitPage(QWebPage):
     self.mainFrame().javaScriptWindowObjectCleared.connect(self.handleJavaScriptWindowObjectCleared)
     self.mainFrame().urlChanged.connect(self.handleUrlChanged)
     self.mainFrame().titleChanged.connect(self.handleTitleChanged)
-    self.mainFrame().pageChanged.connect(self.handlePageChanged)
+    if hasattr(self.mainFrame(), 'pageChanged'):
+        self.mainFrame().pageChanged.connect(self.handlePageChanged)
 
     self.setViewportSize(QSize(400, 300))
 


### PR DESCRIPTION
webkitd おもしろそうですね。早速手元で動かしてみたのですが、以下のようなエラーが出まして。

Traceback (most recent call last):
  File "webkitd.py", line 137, in handleNewConnection
    worker = self.**class**.Worker(socket, self.app, self.**class**.Page)
  File "webkitd.py", line 151, in **init**
    self.page = Page(app)
  File "webkitd.py", line 620, in **init**
    self.mainFrame().pageChanged.connect(self.handlePageChanged)
AttributeError: 'QWebFrame' object has no attribute 'pageChanged'

どうもてもとの qt4 (or python-qt4) は pageChanged をキャッチできないようです。ひとまず以下の修正で手元で動かしています。

https://github.com/sekimura/webkitd/commit/7d93f8c728d842d15c407496e15cc36a306a637e
